### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyYAML>=3.11
 prettytable>=0.7.2
 paramiko>=1.15.2
-ansible>=1.9.1
+ansible>=1.9.1,<2.0
 python-novaclient>=2.24.1
 python-neutronclient>=2.5.0
 python-glanceclient>=0.18.0


### PR DESCRIPTION
Import in utils/ansibleutils.py fail due to changes in ansible from 2.0
This is a temporary fix until compatibility with ansible >=2.0 is introduced.
